### PR TITLE
Support the newer format's field timestamp_ms along with the older timestamp field

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -568,7 +568,7 @@ function read(files){
             message = thread_messages[i]
             message_info = {
               'sender_name': decodeURIComponent(escape(message['sender_name'])),
-              'timestamp': message['timestamp'],
+              'timestamp': message['timestamp'] || (message['timestamp_ms'] / 1000),
               'type': message['type'],
             }
 


### PR DESCRIPTION
I have tested this on data dumped from my facebook account yesterday, works perfectly!

Additionally, I have not discarded the older format either.

While I am not familiar with all data format changes, since this change seems to be enough for the dump I took from facebook yesterday, I think this should fix https://github.com/adurivault/FBMessage/issues/1