### PR TITLE
Handle 2024 data

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,19 @@ The goal of this project is to allow you to visualize your own Facebook Messages
 ## How does it work ?
 
 ### Create your datafile from your Facebook History
-First, you should extract your data from Facebook in JSON format [here](https://www.facebook.com/your_information/). Once you've got your data ready, you can go on the [website](https://adurivault.github.io/FBMessage/).
+First, you should extract your data from Facebook in JSON format [here](https://www.facebook.com/your_information/). Unzip the file. There should be a `messages` folder inside. Once you've got your data ready, you can go on the [website](https://adurivault.github.io/FBMessage/).
+
+#### Encrypted conversations (as of 2025)
+The above method only includes unecrypted messages. Meta enabled encryption on the majority of one-on-one conversations, meaning those conversations will only be downloaded up to the encryption cutoff. Encryption does not, as of now, affect group chats. To download your encrypted data, follow [this guide](https://www.facebook.com/help/messenger-app/677912386869109). Then, unpack the `messages.zip` file to a folder named `encrypted`. Place the `encrypted` folder inside the `messages` folder.
+
+If you've downloaded both the unecrypted and encrypted data, your folder structure should look something like this:
+```
+messages/
+|- e2ee_cutover/
+|- encrypted/
+|- inbox
+|- ...
+```
 
 ## Video Presentation
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ If you've downloaded both the unecrypted and encrypted data, your folder structu
 messages/
 |- e2ee_cutover/
 |- encrypted/
-|- inbox
+|- inbox/
 |- ...
 ```
 


### PR DESCRIPTION
I've downloaded my Facebook Messenger data again to use my favorite data analysis app and realized it doesn't work anymore :(

But then I decided to go further into it, since I've done a similar project and I was able to relatively quickly fix the issues.

### Issue no.1 - Missing "type"
Messages that you download in JSON format, for some reason, don't have a `type` field anymore. It caused a weird bug with the sorting algorithm that would overflow the stack. I fixed it with a simple default "Generic" type for messages that don't have a type in the JSON.

### Issue no. 2 - Encrypted messages
Meta introduced end-to-end encryption in many chats. The download process is different for the encrypted and unecrypted chats. The format is slightly different, as well, but close enough that a few lines of code was enough to be able to read both the unecrypted and encrypted data. I also updated the README to explain the process of obtaining the encrypted data.